### PR TITLE
Bugfix/#5 issue with empty planes

### DIFF
--- a/.github/workflows/cmake_alpine_linux.yml
+++ b/.github/workflows/cmake_alpine_linux.yml
@@ -18,7 +18,6 @@ env:
 
 jobs:
   build:
-    #if: false  # temporarily disabled
     runs-on: ubuntu-latest
     container:
       image: alpine:latest

--- a/.github/workflows/cmake_windows_arm64.yml
+++ b/.github/workflows/cmake_windows_arm64.yml
@@ -49,7 +49,18 @@ jobs:
           # Note that since we are doing a cross compilation, we cannot execute code in order to determine platform
           # characteristics like endianess and whether unaligned access is allowed. Therefore, we need to set the following
           # variables manually: CRASH_ON_UNALIGNED_ACCESS=OFF and IS_BIG_ENDIAN=FALSE.
-          cmake -A "${ARCHITECTURE}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DCRASH_ON_UNALIGNED_ACCESS=OFF -DIS_BIG_ENDIAN=FALSE -DCZIPYRAMIDIZER_BUILD_UNITTESTS=OFF -DLIBCZI_BUILD_CURL_BASED_STREAM=ON -DLIBCZI_BUILD_AZURESDK_BASED_STREAM=ON -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake  -DVCPKG_TARGET_TRIPLET=arm64-windows-static ..
+          cmake -A "${ARCHITECTURE}" \
+              -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+              -DCRASH_ON_UNALIGNED_ACCESS=OFF \
+              -DIS_BIG_ENDIAN=FALSE \
+              -DCZIPYRAMIDIZER_BUILD_UNITTESTS=OFF \
+              -DLIBCZI_BUILD_CURL_BASED_STREAM=ON \
+              -DLIBCZI_BUILD_AZURESDK_BASED_STREAM=ON \
+              -DLIBCZI_BUILD_PREFER_EXTERNALPACKAGE_LIBCURL=ON \
+              -DADDITIONAL_LIBS_REQUIRED_FOR_ATOMIC:STRING= \
+              -DNEON_INTRINSICS_CAN_BE_USED=TRUE \
+              -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake \
+              -DVCPKG_TARGET_TRIPLET=arm64-windows-static ..
 
       - name: Build
         shell: bash

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: never()
+        if: ${{ false }}
         uses: actions/upload-artifact@v4
         with:
           name: MegaLinter reports

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -23,21 +23,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
-
-      - name: Install CMake configure dependencies
-        run: sudo apt-get update && sudo apt-get install -y libopencv-dev ninja-build
-
-      - name: Configure CMake
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCZIPYRAMIDIZER_BUILD_UNITTESTS=OFF
+        uses: actions/checkout@v4
 
       # MegaLinter
       - name: MegaLinter
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter/flavors/dotnet@v9
+        uses: oxsecurity/megalinter/flavors/dotnet@v7
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
           VALIDATE_ALL_CODEBASE: true
+
+      # Upload MegaLinter artifacts
+      - name: Archive production artifacts
+        if: never()
+        uses: actions/upload-artifact@v4
+        with:
+          name: MegaLinter reports
+          path: |
+            megalinter-reports
+            mega-linter.log

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # MegaLinter
       - name: MegaLinter
@@ -35,13 +35,3 @@ jobs:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
           VALIDATE_ALL_CODEBASE: true
-
-      # Upload MegaLinter artifacts
-      - name: Archive production artifacts
-        if: false
-        uses: actions/upload-artifact@v4
-        with:
-          name: MegaLinter reports
-          path: |
-            megalinter-reports
-            mega-linter.log

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
 
+      - name: Install CMake configure dependencies
+        run: sudo apt-get update && sudo apt-get install -y libopencv-dev ninja-build
+
+      - name: Configure CMake
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCZIPYRAMIDIZER_BUILD_UNITTESTS=OFF
+
       # MegaLinter
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -30,7 +30,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter/flavors/dotnet@v7
+        uses: oxsecurity/megalinter/flavors/dotnet@v9
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -9,6 +9,8 @@ DISABLE_ERRORS_LINTERS:
 DISABLE_LINTERS:
   - REPOSITORY_TRIVY  # this linter seems currently broken, so we disable it here for now
   - C_CPPLINT
+CPP_CPPCHECK_CLI_LINT_MODE: project
+CPP_CPPCHECK_ARGUMENTS: --project=build/compile_commands.json
 CPP_CPPLINT_ARGUMENTS: --verbose=2
 JSON_JSONLINT_ARGUMENTS: --comments # Allow comments in JSON files
 DOCKERFILE_HADOLINT_ARGUMENTS: --ignore DL3008 # Ignore "pin versions in pip" warning

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -9,7 +9,7 @@ DISABLE_ERRORS_LINTERS:
 DISABLE_LINTERS:
   - REPOSITORY_TRIVY  # this linter seems currently broken, so we disable it here for now
   - C_CPPLINT
-  - REPOSITORY_GRYPE # this linter seems currently broken, so we disable it here for now 
+  - REPOSITORY_GRYPE # this linter seems currently broken, so we disable it here for now
 CPP_CPPLINT_ARGUMENTS: --verbose=2
 JSON_JSONLINT_ARGUMENTS: --comments # Allow comments in JSON files
 DOCKERFILE_HADOLINT_ARGUMENTS: --ignore DL3008 # Ignore "pin versions in pip" warning

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -9,8 +9,6 @@ DISABLE_ERRORS_LINTERS:
 DISABLE_LINTERS:
   - REPOSITORY_TRIVY  # this linter seems currently broken, so we disable it here for now
   - C_CPPLINT
-CPP_CPPCHECK_CLI_LINT_MODE: project
-CPP_CPPCHECK_ARGUMENTS: --project=build/compile_commands.json
 CPP_CPPLINT_ARGUMENTS: --verbose=2
 JSON_JSONLINT_ARGUMENTS: --comments # Allow comments in JSON files
 DOCKERFILE_HADOLINT_ARGUMENTS: --ignore DL3008 # Ignore "pin versions in pip" warning

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,6 +1,7 @@
 ---
 APPLY_FIXES: none
 DISABLE:
+  - C # Disable C linters; this repo's headers are C++ headers
   - COPYPASTE # Comment to enable checks of excessive copy-pastes
   - SPELL # Comment to enable checks of spelling mistakes
 DISABLE_ERRORS_LINTERS:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -9,6 +9,7 @@ DISABLE_ERRORS_LINTERS:
 DISABLE_LINTERS:
   - REPOSITORY_TRIVY  # this linter seems currently broken, so we disable it here for now
   - C_CPPLINT
+  - REPOSITORY_GRYPE # this linter seems currently broken, so we disable it here for now 
 CPP_CPPLINT_ARGUMENTS: --verbose=2
 JSON_JSONLINT_ARGUMENTS: --comments # Allow comments in JSON files
 DOCKERFILE_HADOLINT_ARGUMENTS: --ignore DL3008 # Ignore "pin versions in pip" warning

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
  
 project(czi-pyramidizer
-      VERSION 0.1.1
+      VERSION 0.1.2
       HOMEPAGE_URL "https://dev.azure.com/ZEISSgroup/RMS-DEV/_git/czi_pyramidizer"
       DESCRIPTION "generate image-pyramid")
 

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,8 +1,7 @@
-version history                 {#version_history}
-============
+# Version history
 
  version            | PR                                                     | comment
  ------------------ |--------------------------------------------------------| ---------------------------------------------------
  0.1.0              | N/A                                                    | initial release
  0.1.1              | N/A                                                    | update libCZI-configuration
- 0.1.2              | [1](https://github.com/ZEISS/czi-pyramidizer/pull/6)   | fix crash when a plane is empty or sparse
+ 0.1.2              | [6](https://github.com/ZEISS/czi-pyramidizer/pull/6)   | fix crash when a plane is empty or sparse

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -5,4 +5,4 @@ version history                 {#version_history}
  ------------------ |--------------------------------------------------------| ---------------------------------------------------
  0.1.0              | N/A                                                    | initial release
  0.1.1              | N/A                                                    | update libCZI-configuration
- 0.1.2              | [1](https://github.com/ZEISS/czi-pyramidizer/pull/1)   | fix crash when a plane is empty or sparse
+ 0.1.2              | [1](https://github.com/ZEISS/czi-pyramidizer/pull/6)   | fix crash when a plane is empty or sparse

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,0 +1,8 @@
+version history                 {#version_history}
+============
+
+ version            | PR                                                     | comment
+ ------------------ |--------------------------------------------------------| ---------------------------------------------------
+ 0.1.0              | N/A                                                    | initial release
+ 0.1.1              | N/A                                                    | update libCZI-configuration
+ 0.1.2              | [1](https://github.com/ZEISS/czi-pyramidizer/pull/1)   | fix crash when a plane is empty or sparse

--- a/libpyramidizer-unittests/pyramidizer_operation_test.cpp
+++ b/libpyramidizer-unittests/pyramidizer_operation_test.cpp
@@ -99,7 +99,7 @@ namespace
         auto spWriterInfo = make_shared<libCZI::CCziWriterInfo>(
             libCZI::GUID{ 0x1234567, 0x89ab, 0xcdef, {1, 2, 3, 4, 5, 6, 7, 8} },  // NOLINT
             libCZI::CDimBounds{ {libCZI::DimensionIndex::C, 0, 3} },  // set a bounds for C
-            0, static_cast<int>(mosaic_info.tiles.size() - 1));  // set a bounds M : 0<=m<=0
+            0, static_cast<int>(mosaic_info.tiles.size() - 1));  // set M bounds: 0<=m<=mosaic_info.tiles.size()-1
         writer->Create(mem_output_stream, spWriterInfo);
 
         for (int channel_no = 0; channel_no < 3; ++channel_no)

--- a/libpyramidizer-unittests/pyramidizer_operation_test.cpp
+++ b/libpyramidizer-unittests/pyramidizer_operation_test.cpp
@@ -46,7 +46,7 @@ namespace
 
         for (size_t i = 0; i < mosaic_info.tiles.size(); ++i)
         {
-            auto bitmap = CreateGray8BitmapAndFill(mosaic_info.tile_width, mosaic_info.tile_height, i + 0x1);
+            auto bitmap = CreateGray8BitmapAndFill(mosaic_info.tile_width, mosaic_info.tile_height, static_cast<uint8_t>(i + 0x1));
             libCZI::AddSubBlockInfoStridedBitmap addSbBlkInfo;
             addSbBlkInfo.Clear();
             addSbBlkInfo.coordinate.Set(libCZI::DimensionIndex::C, 0);
@@ -91,6 +91,71 @@ namespace
         return make_tuple(czi_document_data, czi_document_size);
     }
 
+    tuple<shared_ptr<void>, size_t> CreateMosaicCziWith3ChannelsAndChannel1Empty(const MosaicInfo& mosaic_info)
+    {
+        auto writer = libCZI::CreateCZIWriter();
+        auto mem_output_stream = make_shared<CMemOutputStream>(0);
+
+        auto spWriterInfo = make_shared<libCZI::CCziWriterInfo>(
+            libCZI::GUID{ 0x1234567, 0x89ab, 0xcdef, {1, 2, 3, 4, 5, 6, 7, 8} },  // NOLINT
+            libCZI::CDimBounds{ {libCZI::DimensionIndex::C, 0, 3} },  // set a bounds for C
+            0, static_cast<int>(mosaic_info.tiles.size() - 1));  // set a bounds M : 0<=m<=0
+        writer->Create(mem_output_stream, spWriterInfo);
+
+        for (int channel_no = 0; channel_no < 3; ++channel_no)
+        {
+            if (channel_no == 1)
+            {
+                continue; // skip channel 1 to make it empty
+            }
+
+            for (size_t i = 0; i < mosaic_info.tiles.size(); ++i)
+            {
+                auto bitmap = CreateGray8BitmapAndFill(mosaic_info.tile_width, mosaic_info.tile_height, static_cast<uint8_t>(i + 0x1));
+                libCZI::AddSubBlockInfoStridedBitmap addSbBlkInfo;
+                addSbBlkInfo.Clear();
+                addSbBlkInfo.coordinate.Set(libCZI::DimensionIndex::C, channel_no);
+                addSbBlkInfo.mIndexValid = true;
+                addSbBlkInfo.mIndex = static_cast<int>(i);
+                addSbBlkInfo.x = mosaic_info.tiles[i].x;
+                addSbBlkInfo.y = mosaic_info.tiles[i].y;
+                addSbBlkInfo.logicalWidth = static_cast<int>(bitmap->GetWidth());
+                addSbBlkInfo.logicalHeight = static_cast<int>(bitmap->GetHeight());
+                addSbBlkInfo.physicalWidth = static_cast<int>(bitmap->GetWidth());
+                addSbBlkInfo.physicalHeight = static_cast<int>(bitmap->GetHeight());
+                addSbBlkInfo.PixelType = bitmap->GetPixelType();
+                {
+                    const libCZI::ScopedBitmapLockerSP lock_info_bitmap{ bitmap };
+                    addSbBlkInfo.ptrBitmap = lock_info_bitmap.ptrDataRoi;
+                    addSbBlkInfo.strideBitmap = lock_info_bitmap.stride;
+                    writer->SyncAddSubBlock(addSbBlkInfo);
+                }
+            }
+        }
+
+        const libCZI::PrepareMetadataInfo prepare_metadata_info;
+        auto meta_data_builder = writer->GetPreparedMetadata(prepare_metadata_info);
+        meta_data_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/OriginalCompressionMethod")->SetValue("JpegXr");
+        meta_data_builder->GetRootNode()
+            ->GetOrCreateChildNode("Metadata/Information/Image/OriginalCompressionParameters")
+            ->SetValue("Lossless: False, Quality: 77");
+
+        // NOLINTNEXTLINE: uninitialized struct is OK b/o Clear()
+        libCZI::WriteMetadataInfo write_metadata_info;
+        write_metadata_info.Clear();
+        const auto& strMetadata = meta_data_builder->GetXml();
+        write_metadata_info.szMetadata = strMetadata.c_str();
+        write_metadata_info.szMetadataSize = strMetadata.size() + 1;
+        write_metadata_info.ptrAttachment = nullptr;
+        write_metadata_info.attachmentSize = 0;
+        writer->SyncWriteMetadata(write_metadata_info);
+        writer->Close();
+        writer.reset();
+
+        size_t czi_document_size = 0;
+        const shared_ptr<void> czi_document_data = mem_output_stream->GetCopy(&czi_document_size);
+        return make_tuple(czi_document_data, czi_document_size);
+    }
 
     /// Creates a CZI with four subblocks of size 100x100 of pixeltype "Gray8" in a
     /// mosaic arrangement. The arrangement is as follows:
@@ -120,6 +185,15 @@ namespace
         mosaic_info.tile_height = 1000;
         mosaic_info.tiles = { {3,4}, {2110,370}, {830,1770}, {2330,2010},{999,999},{2003,1453} };
         return CreateMosaicCzi(mosaic_info);
+    }
+
+    tuple<shared_ptr<void>, size_t> CreateCziWith3ChannelsFourSubBlockInMosaicArrangementWithChannel1Empty()
+    {
+        MosaicInfo mosaic_info;
+        mosaic_info.tile_width = 1000;
+        mosaic_info.tile_height = 1000;
+        mosaic_info.tiles = { {3,4}, {2110,370}, {830,1770}, {2330,2010},{999,999},{2003,1453} };
+        return CreateMosaicCziWith3ChannelsAndChannel1Empty(mosaic_info);
     }
 
     libCZI::PyramidStatistics::PyramidLayerStatistics GetPyramidLayerStatisticsForSceneAndLayerNo(const libCZI::PyramidStatistics& pyramid_statistics, int scene_no, int layer_no)
@@ -403,4 +477,86 @@ TEST(PyramidizerOperation, TestSyntheticDocumentAndCheckResult)
 
     static const uint8_t expected_hash[16] = { 0x1e,0xee,0x92,0x05,0x36,0xc3,0x14,0x3e,0x71,0x10,0x7e,0x16,0x27,0x6b,0x06,0x32 };
     ASSERT_TRUE(equal(hash.begin(), hash.end(), expected_hash)) << "The hash of the bitmap of the top-level tile is different than expected.";
+}
+
+TEST(PyramidizerOperation, Test3ChannelDocumentWhereOneChannelIsEmptyAndCheckResult)
+{
+    // call a helper function which creates a simple synthetic document in memory
+    // (we get a pointer to the memory and the size of the memory)
+    auto czi_document_as_blob = CreateCziWith3ChannelsFourSubBlockInMosaicArrangementWithChannel1Empty();
+
+    // create a stream object from this memory
+    const auto memory_stream = make_shared<CMemInputOutputStream>(std::get<0>(czi_document_as_blob).get(), std::get<1>(czi_document_as_blob));
+
+    // create a CZI-writer object on a new memory stream
+    auto writer = libCZI::CreateCZIWriter();
+    auto memory_backed_stream_destination_document = make_shared<CMemInputOutputStream>(0);
+
+    constexpr int argc = 15;
+    std::array<const char*, argc> argv =
+    {
+        "czi-pyramidizer.exe",
+        "-s",
+        "source.czi",
+        "-d",
+        "destination.czi",
+        "--compressionopts",
+        "zstd1:",
+        "--max_top_level_pyramid_size",
+        "64",
+        "--tile_size",
+        "512",
+        "--background-color",
+        "white",
+        "--mode-of-operation",
+        "Always"
+    };
+
+    CommandLineOptions command_line_options;
+    const auto result = command_line_options.Parse(argc, const_cast<char**>(argv.data()));
+    ASSERT_EQ(result, CommandLineOptions::ParseResult::OK);
+
+    // act
+    PyramidizerOperation::PyramidizerOperationOptions pyramidizer_operation_options;
+    pyramidizer_operation_options.command_line_options = &command_line_options;
+    pyramidizer_operation_options.source_stream = memory_stream;
+    pyramidizer_operation_options.get_destination_stream_functor = [memory_backed_stream_destination_document]() { return memory_backed_stream_destination_document; };
+
+    PyramidizerOperation pyramidizer_operation(pyramidizer_operation_options);
+    pyramidizer_operation.Execute();
+
+    /*
+    // for debugging purposes, write the result to a CZI-file
+    FILE* fp = fopen("D:\\test_new.czi", "wb");
+    fwrite(memory_backed_stream_destination_document->GetDataC(), 1, memory_backed_stream_destination_document->GetDataSize(), fp);
+    fclose(fp);*/
+
+    // assert
+    const auto reader_processed_document = libCZI::CreateCZIReader();
+    reader_processed_document->Open(memory_backed_stream_destination_document);
+
+    const auto statistics = reader_processed_document->GetStatistics();
+    const auto pyramid_statistics = reader_processed_document->GetPyramidStatistics();
+
+    // we expect to find 23 * 2 subblocks altogether: 6 on layer-0, 12 on layer-1, 4 on layer-2 and 1 on layer-3 (and this in 2 channels)
+    ASSERT_EQ(statistics.subBlockCount, 46);
+    // Note: numeric_limits<int>::max() is to be used in case of "no s-index used"
+    ASSERT_EQ(GetPyramidLayerStatisticsForSceneAndLayerNo(pyramid_statistics, numeric_limits<int>::max(), 0).count, 2 * 6);
+    ASSERT_EQ(GetPyramidLayerStatisticsForSceneAndLayerNo(pyramid_statistics, numeric_limits<int>::max(), 1).count, 2 * 12);
+    ASSERT_EQ(GetPyramidLayerStatisticsForSceneAndLayerNo(pyramid_statistics, numeric_limits<int>::max(), 2).count, 2 * 4);
+    ASSERT_EQ(GetPyramidLayerStatisticsForSceneAndLayerNo(pyramid_statistics, numeric_limits<int>::max(), 3).count, 2 * 1);
+
+    // Now, we check if there is any sub-block in channel 1. We expect that there is none, since channel 1 was empty in the
+    // input document. If there is at least one sub-block with channel-coordinate 1, then this means that the pyramidizer
+    // operation created a sub-block in channel 1, which should not happen.
+    CDimCoordinate plane_coordinate_channel1{ {DimensionIndex::C, 1} };
+    bool sub_block_in_channel1_found = false;
+    reader_processed_document->EnumSubset(&plane_coordinate_channel1, nullptr, false,
+        [&sub_block_in_channel1_found](int, const SubBlockInfo&)->bool
+        {
+            sub_block_in_channel1_found = true;
+            return true;
+        });
+
+    ASSERT_FALSE(sub_block_in_channel1_found) << "We expect that there is no sub-block in channel 1, since this channel was empty in the input document. However, at least one sub-block with channel-coordinate 1 was found.";
 }

--- a/libpyramidizer/libpyramidizer.cpp
+++ b/libpyramidizer/libpyramidizer.cpp
@@ -62,7 +62,15 @@ namespace
             text = to_string(total_count_of_tiles);
             this->console_io_->WriteStdOut(text); line_length += text.size();
             this->console_io_->SetColor(ConsoleColor::DARK_WHITE, ConsoleColor::DEFAULT);
-            this->console_io_->WriteStdOut(" tiles done."); line_length += 12;
+            if (total_count_of_tiles != 1)
+            {
+                this->console_io_->WriteStdOut(" tiles done."); line_length += 12;
+            }
+            else
+            {
+                this->console_io_->WriteStdOut(" tile done."); line_length += 11;
+            }
+
             this->console_io_->SetColor(ConsoleColor::DEFAULT, ConsoleColor::DEFAULT);
             this->ClearRemainderAndSetNewLineLength(line_length);
             this->console_io_->WriteStdOut("\r");
@@ -90,7 +98,15 @@ namespace
             text = to_string(total_count_of_tiles);
             this->console_io_->WriteStdOut(text); line_length += text.size();
             this->console_io_->SetColor(ConsoleColor::DARK_WHITE, ConsoleColor::DEFAULT);
-            this->console_io_->WriteStdOut(" subblocks done."); line_length += 16;
+            if (total_count_of_tiles != 1)
+            {
+                this->console_io_->WriteStdOut(" subblocks done."); line_length += 16;
+            }
+            else
+            {
+                this->console_io_->WriteStdOut(" subblock done."); line_length += 15;
+            }
+
             this->console_io_->SetColor(ConsoleColor::DEFAULT, ConsoleColor::DEFAULT);
             this->ClearRemainderAndSetNewLineLength(line_length);
             this->console_io_->WriteStdOut("\r");

--- a/libpyramidizer/src/do_pyramidize.cpp
+++ b/libpyramidizer/src/do_pyramidize.cpp
@@ -222,9 +222,20 @@ DoPyramidize::PyramidRegionInfo DoPyramidize::Impl::DoPlane(const PlaneEnumerato
 
     if (!is_additional_pyramid_layer_needed)
     {
+        bool at_least_one_pyramid_tile = false;
+
         // If we only need one layer, we do not have to keep the tiles of the next layer (in order to create the next layer).
-        this->DoLayer0(pyramid_region, nullptr);
-        pyramid_region_info.number_of_pyramid_layers = 1;
+        this->DoLayer0(
+            pyramid_region, 
+            [&](const std::shared_ptr<libCZI::IBitmapData>& pyramid_tile, const libCZI::IntRect& rect)->void
+            {
+                at_least_one_pyramid_tile = true;
+            });
+
+        if (at_least_one_pyramid_tile)
+        {
+            pyramid_region_info.number_of_pyramid_layers = 1;
+        }
     }
     else
     {
@@ -239,6 +250,13 @@ DoPyramidize::PyramidRegionInfo DoPyramidize::Impl::DoPlane(const PlaneEnumerato
                     {
                         next_layer_tiles.emplace_back(make_shared<TileShim>(pyramid_tile, rect));
                     });
+                if (next_layer_tiles.empty())
+                {
+                    // this can happen if there are no valid tiles in the layer-0 (e.g. if the image is very sparse). 
+                    // In this case, we do not have to create any more layers, and we are done
+                    break;
+                }
+
                 pyramid_region_info.number_of_pyramid_layers = 1;
             }
             else
@@ -280,6 +298,13 @@ DoPyramidize::PyramidRegionInfo DoPyramidize::Impl::DoPlane(const PlaneEnumerato
 
                 UpperPyramidLayersPyramidizer upper_layers_pyramidizer(upper_layer_pyramidizer_options);
                 upper_layers_pyramidizer.Execute();
+                if (next_layer_tiles.empty())
+                {
+                    // this can happen if there are no valid tiles in the layer (e.g. if the image is very sparse). 
+                    // In this case, we do not have to create any more layers, and we are done
+                    break;
+                }
+
                 ++pyramid_region_info.number_of_pyramid_layers;
             }
         }

--- a/libpyramidizer/src/do_pyramidize.cpp
+++ b/libpyramidizer/src/do_pyramidize.cpp
@@ -227,7 +227,7 @@ DoPyramidize::PyramidRegionInfo DoPyramidize::Impl::DoPlane(const PlaneEnumerato
         // If we only need one layer, we do not have to keep the tiles of the next layer (in order to create the next layer).
         this->DoLayer0(
             pyramid_region,
-            [&at_least_one_pyramid_tile](const std::shared_ptr<libCZI::IBitmapData>& pyramid_tile, const libCZI::IntRect& rect)->void
+            [&at_least_one_pyramid_tile](const std::shared_ptr<libCZI::IBitmapData>&, const libCZI::IntRect&)->void
             {
                 at_least_one_pyramid_tile = true;
             });

--- a/libpyramidizer/src/do_pyramidize.cpp
+++ b/libpyramidizer/src/do_pyramidize.cpp
@@ -226,8 +226,8 @@ DoPyramidize::PyramidRegionInfo DoPyramidize::Impl::DoPlane(const PlaneEnumerato
 
         // If we only need one layer, we do not have to keep the tiles of the next layer (in order to create the next layer).
         this->DoLayer0(
-            pyramid_region, 
-            [&](const std::shared_ptr<libCZI::IBitmapData>& pyramid_tile, const libCZI::IntRect& rect)->void
+            pyramid_region,
+            [&at_least_one_pyramid_tile](const std::shared_ptr<libCZI::IBitmapData>& pyramid_tile, const libCZI::IntRect& rect)->void
             {
                 at_least_one_pyramid_tile = true;
             });


### PR DESCRIPTION
## Description

The code did not handle the case properly if a plane is empty (or if it is only sparsely covered). This PR fixes this - if the pyramid-generation did not create any output, then the loop is exited early.

Fixes #5 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

testing with the CZI provided in the bug-report

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of czi-pyramidizer
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.