### PR TITLE
Improve SBOM component metadata for release packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
  
 project(czi-pyramidizer
-      VERSION 0.1.3
+      VERSION 0.1.4
       HOMEPAGE_URL "https://dev.azure.com/ZEISSgroup/RMS-DEV/_git/czi_pyramidizer"
       DESCRIPTION "generate image-pyramid")
 

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -6,3 +6,4 @@
  0.1.1              | N/A                                                    | update libCZI-configuration
  0.1.2              | [6](https://github.com/ZEISS/czi-pyramidizer/pull/6)   | fix crash when a plane is empty or sparse
  0.1.3              | [8](https://github.com/ZEISS/czi-pyramidizer/pull/8)   | add release GH workflow
+ 0.1.4              | [9](https://github.com/ZEISS/czi-pyramidizer/pull/9)   | improve SBOM component metadata for release packaging

--- a/release/sbom-components.json
+++ b/release/sbom-components.json
@@ -81,7 +81,7 @@
       "downloadLocation": "https://curl.se/",
       "licenseDeclared": "curl",
       "licenseConcluded": "curl",
-      "copyrightText": "NOASSERTION",
+      "copyrightText": "Copyright (c) 1996 - 2026, Daniel Stenberg, <daniel@haxx.se>, and many contributors, see the THANKS file.",
       "purpose": "LIBRARY"
     },
     {


### PR DESCRIPTION
## Description

This PR improves the metadata in release/sbom-components.json used for generating release SPDX SBOMs.
In particular, it fills in package-level copyright/license details where we have clear and reliable source material from the packaged dependency metadata, most notably for curl.
The goal is to make the generated SBOMs more complete and better aligned with the expectations for binary release documentation.

Notes:
* some components such as OpenCV, OpenSSL, and Iconv still retain NOASSERTION in places where the currently available upstream/package metadata does not provide a single clean package-level copyright statement
* this PR is limited to metadata cleanup and does not change the release workflow structure

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

locally

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of czi-pyramidizer
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.